### PR TITLE
Shortcut on self in Principal::map()

### DIFF
--- a/src/Pipeline/Principal.php
+++ b/src/Pipeline/Principal.php
@@ -43,6 +43,14 @@ abstract class Principal implements Interfaces\Pipeline
 
     public function map(callable $func)
     {
+        // If we know the callback is one of us, we can use a shortcut
+        // This also allows inheriting classes to replace the pipeline
+        if ($func instanceof self) {
+            $this->pipeline = call_user_func($func);
+
+            return $this;
+        }
+
         if (!$this->pipeline) {
             $this->pipeline = call_user_func($func);
 

--- a/tests/Pipeline/SimpleTest.php
+++ b/tests/Pipeline/SimpleTest.php
@@ -181,8 +181,7 @@ class SimpleTest extends TestCase
         });
 
         $pipeline2 = new Simple();
-        $pipeline2->map($pipeline1);
-        $pipeline2->filter(function ($i) {
+        $pipeline2->map($pipeline1)->filter(function ($i) {
             return $i % 2 != 0;
         });
 


### PR DESCRIPTION
If in `Principal::map()` we know the callback is one of us, we can use a shortcut.

This also allows inheriting classes to replace the pipeline.