### PR TITLE
Mappers should try to preserve keys

### DIFF
--- a/src/Principal.php
+++ b/src/Principal.php
@@ -87,16 +87,18 @@ abstract class Principal implements \IteratorAggregate, \Countable
 
     private static function apply(iterable $previous, callable $func): iterable
     {
-        foreach ($previous as $value) {
+        foreach ($previous as $key => $value) {
             $result = $func($value);
+
+            // For generators we use keys they provide
             if ($result instanceof \Generator) {
                 yield from $result;
 
                 continue;
             }
 
-            // Case of a plain old mapping function
-            yield $result;
+            // In case of a plain old mapping function we use the original key
+            yield $key => $result;
         }
     }
 
@@ -131,8 +133,8 @@ abstract class Principal implements \IteratorAggregate, \Countable
 
     private static function applyOnce(iterable $previous, callable $func): iterable
     {
-        foreach ($previous as $value) {
-            yield $func($value);
+        foreach ($previous as $key => $value) {
+            yield $key => $func($value);
         }
     }
 

--- a/tests/CastTest.php
+++ b/tests/CastTest.php
@@ -88,4 +88,18 @@ final class CastTest extends TestCase
 
         $this->assertSame([0, 2, 6], $pipeline->toArray());
     }
+
+    public function testCastPreservesKeys(): void
+    {
+        $this->assertSame([
+            'a' => 2,
+            'b' => 6,
+        ], map(function () {
+            yield 'a' => 1;
+            yield 'b' => 2;
+            yield 'b' => 3;
+        })->cast(function (int $a) {
+            return $a * 2;
+        })->toArray(true));
+    }
 }

--- a/tests/MapTest.php
+++ b/tests/MapTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright 2017, 2018 Alexey Kopytko <alexey@kopytko.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Pipeline;
+
+use PHPUnit\Framework\TestCase;
+use function Pipeline\map;
+
+/**
+ * @covers \Pipeline\Principal
+ * @covers \Pipeline\Standard
+ *
+ * @internal
+ */
+final class MapTest extends TestCase
+{
+    public function testMapPreservesKeys(): void
+    {
+        $this->assertSame([
+            'a' => 2,
+            'b' => 6,
+        ], map(function () {
+            yield 'a' => 1;
+            yield 'b' => 2;
+            yield 'b' => 3;
+        })->map(function (int $a) {
+            return $a * 2;
+        })->toArray(true));
+    }
+}


### PR DESCRIPTION
Fixes #84

Iterating over a generator with keys seems to be less than 1% slower.

Some benchmarks: 
- https://3v4l.org/pV8K6
- https://3v4l.org/AfUBN