### PR TITLE
Add slice() method

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
             composer-
 
       - name: Set package version for Composer
-        uses: "ergebnis/composer-root-version-action@main"
+        uses: ergebnis/composer-root-version-action@0.2.1
         with:
           branch: "main"
 
@@ -123,6 +123,11 @@ jobs:
           restore-keys: |
             composer-${{ env.PHP_VERSION }}-
             composer-
+
+      - name: Set package version for Composer
+        uses: ergebnis/composer-root-version-action@0.2.1
+        with:
+          branch: "main"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,11 @@ jobs:
             composer-${{ matrix.php-version }}-
             composer-
 
+      - name: Set package version for Composer
+        uses: "ergebnis/composer-root-version-action@main"
+        with:
+          branch: "main"
+
       - name: Install dependencies
         run: |
           composer remove --no-update --dev \

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ All entry points always return an instance of a standard pipeline.
 | `zip()`  | Takes a number of iterables, merging them together with the current sequence, if any.  | `array_map(null, ...$array)`, Python's `zip()`, transposition |
 | `unpack()`  | Unpacks arrays into arguments for a callback. Flattens inputs if no callback provided. |  `flat_map`, `flatten`                 |
 | `filter()`  | Removes elements unless a callback returns true. Removes falsey values if no callback provided.  |  `array_filter`, `Where`                |
+| `slice()`  | Extracts a slice from the inputs. Keys are not discarded intentionally. Suppors negative values for both arguments. |  `array_slice`                |
 | `reduce()`  | Reduces input values to a single value. Defaults to summation. Requires an initial value. | `array_reduce`, `Aggregate`, `Sum` |
 | `toArray()` | Returns an array with all values. Eagerly executed. | `dict`, `ToDictionary` |
 | `__construct()` | Can be provided with an optional initial iterator. Used in the `take()` function from above. Not part of any interface as per LSP. |     |
@@ -327,6 +328,17 @@ $pipeline->filter(function ($item) {
 
 Standard pipeline has a default callback with the same effect as in `array_filter`: it'll remove all falsy values.
 
+## `$pipeline->slice()`
+
+Takes offset and length arguments, functioning in a very similar fashion to how `array_slice` does with `$preserve_keys` set to true.
+
+```php
+$pipeline->slice(1, -1);
+```
+This example will remove first and last elements of the sequence.
+
+Implementation uses a rolling window buffer for negative values of offset and length, and falls back on plain old `array_slice` for input arrays.
+
 ## `$pipeline->reduce()`
 
 Takes a reducing callback not unlike that of `array_reduce` with two arguments for the value of the previous iteration and for the current item.
@@ -393,7 +405,7 @@ What else is out there:
 
 - [Pipe operator from Hack](https://docs.hhvm.com/hack/operators/pipe-operator) is about same, only won't work for generators, and not under the regular PHP. [See a proposal for a similar operator for JavaScript.](https://github.com/tc39/proposal-pipeline-operator)
 
-- [Iteration primitives using generators](https://github.com/nikic/iter) provide functions like array_map and such, but returning lazy generators. You'll need quite some glue to accomplish the same thing Pipeline does out of box.
+- [`nikic/iter`](https://github.com/nikic/iter) provides functions like array_map and such, but returning lazy generators. You'll need quite some glue to accomplish the same thing Pipeline does out of box, not to mention some missing features.
 
 - [League\Pipeline](https://github.com/thephpleague/pipeline) is good for single values only. Similar name, but very different purpose. Not supposed to work with sequences of values. Each stage may return only one value.
 

--- a/example.php
+++ b/example.php
@@ -125,16 +125,15 @@ $pipeline->map(function ($value) {
     yield $value + 2;
 });
 
+// remove first and last elements
+$pipeline->slice(1, -1);
+
 $arrayResult = $pipeline->toArray();
 var_dump($arrayResult);
 // Since keys are discarded we get:
 // array(4) {
 //     [0] =>
-//     int(2)
+//     int(3)
 //     [1] =>
 //     int(3)
-//     [2] =>
-//     int(3)
-//     [3] =>
-//     int(4)
 // }

--- a/src/Interfaces/StandardPipeline.php
+++ b/src/Interfaces/StandardPipeline.php
@@ -67,6 +67,18 @@ interface StandardPipeline extends \IteratorAggregate, \Countable
     public function filter(?callable $func = null);
 
     /**
+     * Extracts a slice from the inputs. Keys are not discarded intentionally.
+     *
+     * @see \array_slice()
+     *
+     * @param int  $offset If offset is non-negative, the sequence will start at that offset. If offset is negative, the sequence will start that far from the end.
+     * @param ?int $length If length is given and is positive, then the sequence will have up to that many elements in it. If length is given and is negative then the sequence will stop that many elements from the end.
+     *
+     * @return $this
+     */
+    public function slice(int $offset, ?int $length = null);
+
+    /**
      * Reduces input values to a single value. Defaults to summation. This is a terminal operation.
      *
      * @param ?callable $func    function (mixed $carry, mixed $item) { must return updated $carry }

--- a/src/Principal.php
+++ b/src/Principal.php
@@ -211,7 +211,7 @@ abstract class Principal implements \IteratorAggregate, \Countable
      *
      * This is a terminal operation.
      *
-     * @see Countable::count()
+     * @see \Countable::count()
      */
     public function count(): int
     {
@@ -231,6 +231,133 @@ abstract class Principal implements \IteratorAggregate, \Countable
         }
 
         return \count($this->pipeline);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return $this
+     */
+    public function slice(int $offset, ?int $length = null)
+    {
+        if (null === $this->pipeline) {
+            // With non-primed pipeline just move along.
+            return $this;
+        }
+
+        if (0 === $length) {
+            // We're not consuming anything assuming total laziness.
+            $this->pipeline = null;
+
+            return $this;
+        }
+
+        // Shortcut to array_slice() for actual arrays.
+        if (\is_array($this->pipeline)) {
+            $this->pipeline = \array_slice($this->pipeline, $offset, $length, true);
+
+            return $this;
+        }
+
+        if ($offset < 0) {
+            // If offset is negative, the sequence will start that far from the end of the array.
+            $this->pipeline = self::tail($this->pipeline, -$offset);
+        }
+
+        if ($offset > 0) {
+            // @infection-ignore-all
+            \assert($this->pipeline instanceof \Iterator);
+
+            // If offset is non-negative, the sequence will start at that offset in the array.
+            $this->pipeline = self::skip($this->pipeline, $offset);
+        }
+
+        if ($length < 0) {
+            // If length is given and is negative then the sequence will stop that many elements from the end of the array.
+            $this->pipeline = self::head($this->pipeline, -$length);
+        }
+
+        if ($length > 0) {
+            // If length is given and is positive, then the sequence will have up to that many elements in it.
+            $this->pipeline = self::take($this->pipeline, $length);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @psalm-param positive-int $skip
+     */
+    private static function skip(\Iterator $input, int $skip): iterable
+    {
+        // Consume until seen enough.
+        foreach ($input as $_) {
+            if (0 === $skip--) {
+                break;
+            }
+        }
+
+        // Avoid yielding from an exhausted generator. Gives error:
+        // Generator passed to yield from was aborted without proper return and is unable to continue
+        if (!$input->valid()) {
+            return;
+        }
+
+        yield from $input;
+    }
+
+    /**
+     * @psalm-param positive-int $take
+     */
+    private static function take(iterable $input, int $take): iterable
+    {
+        foreach ($input as $key => $value) {
+            yield $key => $value;
+
+            // Stop once taken enough.
+            if (0 === --$take) {
+                break;
+            }
+        }
+    }
+
+    private static function tail(iterable $input, int $length): iterable
+    {
+        $buffer = [];
+
+        foreach ($input as $key => $value) {
+            if (\count($buffer) < $length) {
+                // Read at most N records.
+                $buffer[] = [$key, $value];
+
+                continue;
+            }
+
+            // Remove and add one record each time.
+            \array_shift($buffer);
+            $buffer[] = [$key, $value];
+        }
+
+        foreach ($buffer as list($key, $value)) {
+            yield $key => $value;
+        }
+    }
+
+    /**
+     * Allocates a buffer of $length, and reads records into it, proceeding with FIFO when buffer is full.
+     */
+    private static function head(iterable $input, int $length): iterable
+    {
+        $buffer = [];
+
+        foreach ($input as $key => $value) {
+            $buffer[] = [$key, $value];
+
+            if (\count($buffer) > $length) {
+                [$key, $value] = \array_shift($buffer);
+                yield $key => $value;
+            }
+        }
     }
 
     /**

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -44,6 +44,6 @@ final class ExampleTest extends TestCase
         $this->assertSame(104, $value);
         $this->assertSame(6, $sum);
         $this->assertSame([22, 42, 62], $result);
-        $this->assertSame([2, 3, 3, 4], $arrayResult);
+        $this->assertSame([3, 3], $arrayResult);
     }
 }

--- a/tests/SliceTest.php
+++ b/tests/SliceTest.php
@@ -71,7 +71,7 @@ final class SliceTest extends TestCase
 
         $this->assertSame(
             [2, 3, 4, 5],
-            $example()->slice(1, -1)->toArray(true)
+            $example()->slice(1, -1)->toArray()
         );
     }
 

--- a/tests/SliceTest.php
+++ b/tests/SliceTest.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * Copyright 2017, 2018 Alexey Kopytko <alexey@kopytko.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Pipeline;
+
+use PHPUnit\Framework\TestCase;
+use function Pipeline\fromArray;
+use function Pipeline\map;
+use Pipeline\Standard;
+
+/**
+ * @covers \Pipeline\Principal
+ *
+ * @internal
+ */
+final class SliceTest extends TestCase
+{
+    public static function specimens(): iterable
+    {
+        yield [
+            'expected' => [],
+            'input' => [],
+            'offset' => 0,
+        ];
+
+        yield [
+            'expected' => [
+                0 => 3,
+                23 => 4,
+            ],
+            'input' => ['one' => 1, 'two' => 2, 3, 23 => 4],
+            'offset' => 2,
+            'length' => 2,
+            'useKeys' => true,
+        ];
+
+        yield [
+            'expected' => [
+                3,
+                4,
+            ],
+            'input' => ['one' => 1, 'two' => 2, 3, 23 => 4],
+            'offset' => 2,
+        ];
+
+        yield [\range(1, 3), \range(1, 3), 0];
+
+        yield [[], \range(1, 3), 0, 0];
+
+        yield [[3], \range(1, 3), -1];
+
+        yield [[2 => 3], \range(1, 3), -1, null, true];
+
+        $inputs = [
+            [],
+            [1, 2, 3, 4, 5, 6, 7, 8, 9],
+            ['One', 'Two', 'Three', 'Four', 'Five'],
+            [6, 'six', 7, 'seven', 8, 'eight', 9, 'nine'],
+            ['a' => 'aaa', 'A' => 'AAA', 'c' => 'ccc', 'd' => 'ddd', 'e' => 'eee'],
+            ['1' => 'one', '2' => 'two', '3' => 'three', '4' => 'four', '5' => 'five'],
+            [1 => 'one', 2 => 'two', 3 => 7, 4 => 'four', 5 => 'five'],
+            [12, 'name', 'age', '11'],
+            [['oNe', 'tWo', 4], [10, 20, 30, 40, 50], []],
+        ];
+
+        $argsList = [
+            [0],
+            [-2],
+            [1, 3],
+            [1, 0],
+            [0, 3],
+            [0, 0],
+
+            [0, -3],
+            [-2, 3],
+            [-2, 0],
+            [-2, -3],
+
+            [1, -3],
+            [-3, -2],
+
+            [2, -4],
+            [-4, -1],
+            [PHP_INT_MAX],
+            [-PHP_INT_MAX],
+            [PHP_INT_MAX, PHP_INT_MAX],
+            [-PHP_INT_MAX, -PHP_INT_MAX],
+            [PHP_INT_MAX, -PHP_INT_MAX],
+            [-PHP_INT_MAX, PHP_INT_MAX],
+
+            [0, PHP_INT_MAX],
+            [0, -PHP_INT_MAX],
+        ];
+
+        foreach ($inputs as $array) {
+            foreach ($argsList as $args) {
+                $args = $args + [null, null, true];
+
+                yield \array_merge(
+                    [\array_slice($array, ...$args), $array],
+                    $args
+                );
+
+                $args[2] = false;
+
+                yield \array_merge(
+                    [\array_values(\array_slice($array, ...$args)), $array],
+                    $args
+                );
+            }
+        }
+    }
+
+    /**
+     * @dataProvider specimens
+     * @covers \Pipeline\Principal::slice()
+     */
+    public function testSliceWithArrays(array $expected, array $input, int $offset, ?int $length = null, bool $useKeys = false): void
+    {
+        $pipeline = fromArray($input);
+
+        $this->assertSame(
+            $expected,
+            $pipeline->slice($offset, $length)->toArray($useKeys)
+        );
+    }
+
+    /**
+     * @dataProvider specimens
+     * @covers \Pipeline\Principal::slice()
+     */
+    public function testSliceWithIterables(array $expected, array $input, int $offset, ?int $length = null, bool $useKeys = false): void
+    {
+        $pipeline = map(static function () use ($input) {
+            yield from $input;
+        });
+
+        try {
+            $this->assertSame(
+                $expected,
+                $pipeline->slice($offset, $length)->toArray($useKeys)
+            );
+        } catch (\InvalidArgumentException $e) {
+            if ('Not implemented yet' === $e->getMessage()) {
+                $this->markTestIncomplete();
+            }
+        }
+    }
+
+    public function testSliceExample(): void
+    {
+        $pipeline = map(static function () {
+            yield from [1, 2, 3, 4, 5, 6];
+        });
+
+        $this->assertSame(
+            [3, 4, 5],
+            $pipeline->slice(2, 3)->toArray()
+        );
+
+        $pipeline = map(static function () {
+            yield from [1, 2, 3, 4, 5, 6];
+        });
+
+        $this->assertSame(
+            [6],
+            $pipeline->slice(5, 200)->toArray()
+        );
+
+        $pipeline = map(static function () {
+            yield from [1, 2, 3, 4, 5, 6];
+        });
+
+        $this->assertSame(
+            [],
+            $pipeline->slice(15, 200)->toArray()
+        );
+
+        $pipeline = map(static function () {
+            yield from [1, 2, 3, 4, 5, 6];
+        });
+
+        $this->assertSame(
+            [5, 6],
+            $pipeline->slice(-2)->toArray()
+        );
+
+        $pipeline = map(static function () {
+            yield from [1, 2, 3, 4, 5, 6];
+        });
+
+        $this->assertSame(
+            [2, 3, 4],
+            $pipeline->slice(-5, -2)->toArray()
+        );
+
+        $pipeline = map(static function () {
+            yield from [1, 2, 3, 4, 5, 6];
+        });
+
+        $this->assertSame(
+            [1, 2, 3],
+            $pipeline->slice(0, -3)->toArray()
+        );
+    }
+
+    public function testSliceNil(): void
+    {
+        $pipeline = new Standard();
+
+        $this->assertSame([], $pipeline->slice(0)->toArray());
+    }
+
+    public function testNoopZeroOffset(): void
+    {
+        $pipeline = map(function () {
+            throw new \RuntimeException();
+            yield;
+        });
+
+        try {
+            $pipeline->slice(0)->toArray();
+        } catch (\RuntimeException $e) {
+            // We must not have any static methods called.
+            $this->assertStringNotContainsString('Principal::', (string) $e);
+        }
+    }
+}

--- a/tests/SliceTest.php
+++ b/tests/SliceTest.php
@@ -201,6 +201,8 @@ final class SliceTest extends TestCase
 
             [0, PHP_INT_MAX],
             [0, -PHP_INT_MAX],
+            [PHP_INT_MAX, 0],
+            [-PHP_INT_MAX, 0],
         ];
 
         foreach ($inputs as $array) {

--- a/tests/SliceTest.php
+++ b/tests/SliceTest.php
@@ -68,6 +68,11 @@ final class SliceTest extends TestCase
             [1, 2, 3],
             $example()->slice(0, -3)->toArray()
         );
+
+        $this->assertSame(
+            [2, 3, 4, 5],
+            $example()->slice(1, -1)->toArray(true)
+        );
     }
 
     public function testSliceExampleWithKeys(): void
@@ -106,6 +111,11 @@ final class SliceTest extends TestCase
         $this->assertSame(
             ['a' => 1, 'b' => 2, 'c' => 3],
             $example()->slice(0, -3)->toArray(true)
+        );
+
+        $this->assertSame(
+            ['b' => 2, 'c' => 3, 'd' => 4, 'e' => 5],
+            $example()->slice(1, -1)->toArray(true)
         );
     }
 

--- a/tests/SliceTest.php
+++ b/tests/SliceTest.php
@@ -31,6 +31,91 @@ use Pipeline\Standard;
  */
 final class SliceTest extends TestCase
 {
+    public function testSliceExample(): void
+    {
+        $example = static function () {
+            return map(static function () {
+                yield from [1, 2, 3, 4, 5, 6];
+            });
+        };
+
+        $this->assertSame(
+            [3, 4, 5],
+            $example()->slice(2, 3)->toArray()
+        );
+
+        $this->assertSame(
+            [6],
+            $example()->slice(5, 200)->toArray()
+        );
+
+        $this->assertSame(
+            [],
+            $example()->slice(15, 200)->toArray()
+        );
+
+        $this->assertSame(
+            [5, 6],
+            $example()->slice(-2)->toArray()
+        );
+
+        $this->assertSame(
+            [2, 3, 4],
+            $example()->slice(-5, -2)->toArray()
+        );
+
+        $this->assertSame(
+            [1, 2, 3],
+            $example()->slice(0, -3)->toArray()
+        );
+    }
+
+    public function testSliceExampleWithKeys(): void
+    {
+        $example = static function () {
+            return map(static function () {
+                yield from ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5, 'f' => 6];
+            });
+        };
+
+        $this->assertSame(
+            ['c' => 3, 'd' => 4, 'e' => 5],
+            $example()->slice(2, 3)->toArray(true)
+        );
+
+        $this->assertSame(
+            ['f' => 6],
+            $example()->slice(5, 200)->toArray(true)
+        );
+
+        $this->assertSame(
+            [],
+            $example()->slice(15, 200)->toArray(true)
+        );
+
+        $this->assertSame(
+            ['e' => 5, 'f' => 6],
+            $example()->slice(-2)->toArray(true)
+        );
+
+        $this->assertSame(
+            ['b' => 2, 'c' => 3, 'd' => 4],
+            $example()->slice(-5, -2)->toArray(true)
+        );
+
+        $this->assertSame(
+            ['a' => 1, 'b' => 2, 'c' => 3],
+            $example()->slice(0, -3)->toArray(true)
+        );
+    }
+
+    public function testSliceNil(): void
+    {
+        $pipeline = new Standard();
+
+        $this->assertSame([], $pipeline->slice(0)->toArray());
+    }
+
     public static function specimens(): iterable
     {
         yield [
@@ -110,6 +195,7 @@ final class SliceTest extends TestCase
 
         foreach ($inputs as $array) {
             foreach ($argsList as $args) {
+                // First with keys:
                 $args = $args + [null, null, true];
 
                 yield \array_merge(
@@ -117,6 +203,7 @@ final class SliceTest extends TestCase
                     $args
                 );
 
+                // Now without keys:
                 $args[2] = false;
 
                 yield \array_merge(
@@ -161,70 +248,6 @@ final class SliceTest extends TestCase
                 $this->markTestIncomplete();
             }
         }
-    }
-
-    public function testSliceExample(): void
-    {
-        $pipeline = map(static function () {
-            yield from [1, 2, 3, 4, 5, 6];
-        });
-
-        $this->assertSame(
-            [3, 4, 5],
-            $pipeline->slice(2, 3)->toArray()
-        );
-
-        $pipeline = map(static function () {
-            yield from [1, 2, 3, 4, 5, 6];
-        });
-
-        $this->assertSame(
-            [6],
-            $pipeline->slice(5, 200)->toArray()
-        );
-
-        $pipeline = map(static function () {
-            yield from [1, 2, 3, 4, 5, 6];
-        });
-
-        $this->assertSame(
-            [],
-            $pipeline->slice(15, 200)->toArray()
-        );
-
-        $pipeline = map(static function () {
-            yield from [1, 2, 3, 4, 5, 6];
-        });
-
-        $this->assertSame(
-            [5, 6],
-            $pipeline->slice(-2)->toArray()
-        );
-
-        $pipeline = map(static function () {
-            yield from [1, 2, 3, 4, 5, 6];
-        });
-
-        $this->assertSame(
-            [2, 3, 4],
-            $pipeline->slice(-5, -2)->toArray()
-        );
-
-        $pipeline = map(static function () {
-            yield from [1, 2, 3, 4, 5, 6];
-        });
-
-        $this->assertSame(
-            [1, 2, 3],
-            $pipeline->slice(0, -3)->toArray()
-        );
-    }
-
-    public function testSliceNil(): void
-    {
-        $pipeline = new Standard();
-
-        $this->assertSame([], $pipeline->slice(0)->toArray());
     }
 
     public function testNoopZeroOffset(): void


### PR DESCRIPTION
This is a far more complete version of `slice()` than, for example, [`nikic/iter` provides](https://github.com/nikic/iter/blob/ace6ae384334c49054cd4500fcb548755916f2dd/src/iter.php#L492-L530).

