### PR TITLE
Fix slice() with plain iterators

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,8 +21,8 @@ jobs:
         dependencies: ['']
         include:
           - { php-version: '7.1', coverage: 'xdebug', dependencies: '' }
-          - { php-version: '8.0', coverage: 'pcov', dependencies: '--ignore-platform-req=php' }
-          - { php-version: '8.1', coverage: 'pcov', dependencies: '--ignore-platform-req=php' }
+          - { php-version: '8.0', coverage: 'pcov', dependencies: '' }
+          - { php-version: '8.1', coverage: 'pcov', dependencies: '' }
 
     steps:
       - name: Checkout code

--- a/tests/Benchmarks/BenchTest.php
+++ b/tests/Benchmarks/BenchTest.php
@@ -26,7 +26,6 @@ use function Pipeline\fromArray;
 use function random_int;
 
 /**
- * @covers \Pipeline\Principal
  * @covers \Pipeline\Standard
  *
  * @internal


### PR DESCRIPTION
It handled arrays and generators well, but on other iterators it didn't do so well.