### PR TITLE
Add flatten(), a readable shortcut for unpack()

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ All entry points always return an instance of the pipeline.
 | `prepend()` | Appends the contents of an interable to the end of the pipeline. | `array_merge` |
 | `unshift()` | Prepends the pipeline with a list of values. | `array_unshift` |
 | `zip()`  | Takes a number of iterables, transposing them together with the current sequence, if any.  | `array_map(null, ...$array)`, Python's `zip()`, transposition |
-| `unpack()`  | Unpacks arrays into arguments for a callback. Flattens inputs if no callback provided. |  `flat_map`, `flatten`                 |
+| `flatten()` |  Flattens inputs: `[[1, 2], [3, 4]]` becomes `[1, 2, 3, 4]`. |  `flat_map`, `flatten`, `collect_concat`      |
+| `unpack()`  | Unpacks arrays into arguments for a callback. Flattens inputs if no callback provided. |             |
 | `chunk()` | Chunks the pipeline into arrays of specified length. | `array_chunk` |
 | `filter()`  | Removes elements unless a callback returns true. Removes falsey values if no callback provided.  |  `array_filter`, `Where`                |
 | `slice()`  | Extracts a slice from the inputs. Keys are not discarded intentionally. Suppors negative values for both arguments. |  `array_slice`                |
@@ -242,6 +243,18 @@ $pipeline->map(function () {
 });
 ```
 
+## `$pipeline->flatten()`
+
+Flatten inputs:
+
+```php
+$pipeline->map(function () {
+    yield [1];
+    yield [2, 3];
+})->unpack()->toArray();
+// [1, 2, 3]
+```
+
 ## `$pipeline->unpack()`
 
 An extra variant of `map` which unpacks arrays into arguments for a callback.
@@ -269,15 +282,7 @@ $pipeline->unpack(function ($a, array $b, \DateTime ...$dates) {
 
 You can have all kinds of standard type checks with ease too.
 
-With no callback, the default callback for `unpack()` will flatten inputs:
-
-```php
-$pipeline->map(function () {
-    yield [1];
-    yield [2, 3];
-})->unpack()->toArray();
-// [1, 2, 3]
-```
+With no callback, the default callback for `unpack()` will flatten inputs as in `flatten()`.
 
 ## `$pipeline->cast()`
 

--- a/src/Standard.php
+++ b/src/Standard.php
@@ -204,9 +204,9 @@ class Standard implements IteratorAggregate, Countable
      */
     public function unpack(?callable $func = null): self
     {
-        $func = $func ?? static function (...$args) {
-            yield from $args;
-        };
+        if (null === $func) {
+            return $this->flatten();
+        }
 
         return $this->map(static function (iterable $args = []) use ($func) {
             /** @psalm-suppress InvalidArgument */
@@ -219,7 +219,9 @@ class Standard implements IteratorAggregate, Countable
      */
     public function flatten(): self
     {
-        return $this->unpack();
+        return $this->map(static function (iterable $args = []) {
+            yield from $args;
+        });
     }
 
     /**

--- a/src/Standard.php
+++ b/src/Standard.php
@@ -216,8 +216,6 @@ class Standard implements IteratorAggregate, Countable
 
     /**
      * Flattens inputs: arrays become lists.
-     *
-     * @return self
      */
     public function flatten(): self
     {

--- a/src/Standard.php
+++ b/src/Standard.php
@@ -196,6 +196,18 @@ class Standard implements IteratorAggregate, Countable
     }
 
     /**
+     * Flattens inputs: arrays become lists.
+     *
+     * @return $this
+     */
+    public function flatten(): self
+    {
+        return $this->map(static function (iterable $args = []) {
+            yield from $args;
+        });
+    }
+
+    /**
      * An extra variant of `map` which unpacks arrays into arguments. Flattens inputs if no callback provided.
      *
      * @param ?callable $func
@@ -211,18 +223,6 @@ class Standard implements IteratorAggregate, Countable
         return $this->map(static function (iterable $args = []) use ($func) {
             /** @psalm-suppress InvalidArgument */
             return $func(...$args);
-        });
-    }
-
-    /**
-     * Flattens inputs: arrays become lists.
-     *
-     * @return $this
-     */
-    public function flatten(): self
-    {
-        return $this->map(static function (iterable $args = []) {
-            yield from $args;
         });
     }
 

--- a/src/Standard.php
+++ b/src/Standard.php
@@ -215,6 +215,16 @@ class Standard implements IteratorAggregate, Countable
     }
 
     /**
+     * Flattens inputs: arrays become lists.
+     *
+     * @return self
+     */
+    public function flatten(): self
+    {
+        return $this->unpack();
+    }
+
+    /**
      * Chunks the pipeline into arrays with length elements. The last chunk may contain less than length elements.
      *
      * @param int<1, max> $length        the size of each chunk

--- a/src/Standard.php
+++ b/src/Standard.php
@@ -216,6 +216,8 @@ class Standard implements IteratorAggregate, Countable
 
     /**
      * Flattens inputs: arrays become lists.
+     *
+     * @return $this
      */
     public function flatten(): self
     {

--- a/tests/UnpackTest.php
+++ b/tests/UnpackTest.php
@@ -81,4 +81,16 @@ final class UnpackTest extends TestCase
             [3],
         ])->unpack()->toArray());
     }
+
+    /**
+     * @covers \Pipeline\Standard::flatten()
+     */
+    public function testFlatten(): void
+    {
+        $this->assertSame([1, 2, 3], fromArray([
+            new ArrayIterator([1]),
+            fromArray([2]),
+            [3],
+        ])->flatten()->toArray());
+    }
 }


### PR DESCRIPTION
Since it is hard to understand what `unpack()` does without an optional argument, lets add a method with a straightforward meaning.

- [x] Update documentation