### PR TITLE
Discard the state in reservoir() for invalid arguments

### DIFF
--- a/src/Standard.php
+++ b/src/Standard.php
@@ -778,6 +778,9 @@ class Standard implements IteratorAggregate, Countable
         }
 
         if ($size <= 0) {
+            // Discard the state to emulate full consumption
+            $this->pipeline = null;
+
             return [];
         }
 

--- a/tests/ReservoirTest.php
+++ b/tests/ReservoirTest.php
@@ -158,9 +158,15 @@ final class ReservoirTest extends TestCase
      */
     public function testWeightedSampleFromGenerator(array $input, int $size, callable $weightFn, array $expected): void
     {
-        $this->assertSame($expected, map(static function () use ($input) {
+        $pipeline = map(static function () use ($input) {
             yield from $input;
-        })->reservoir($size, $weightFn));
+        });
+
+        $this->assertSame($expected, $pipeline->reservoir($size, $weightFn));
+
+        if ($size <= 0) {
+            $this->assertSame([], $pipeline->toArray());
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #120