### PR TITLE
Test zip() can handle empty argument list

### DIFF
--- a/tests/ZipTest.php
+++ b/tests/ZipTest.php
@@ -148,6 +148,13 @@ final class ZipTest extends TestCase
         $this->assertSame([], $pipeline->zip([])->toArray());
     }
 
+    public function testZipNothingNothing(): void
+    {
+        $pipeline = new Standard();
+
+        $this->assertSame([], $pipeline->zip()->toArray());
+    }
+
     public function testExample(): void
     {
         $iterable = range(5, 7);


### PR DESCRIPTION
Fix #122