### PR TITLE
Fix gitignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /vendor
 /build
 *.cache
-.?*


### PR DESCRIPTION
`.?*` is too broad, ignores already existing files.

Command to detect this error: `git ls-files --cached --ignored --exclude-standard`

[_source_](https://github.com/szepeviktor/byte-level-care/blob/75ebea060ef78f473ee6a5cff80fadadebbd454b/.github/workflows/reusable-integrity.yml#L170-L175)
