### PR TITLE
Fix a bug with slice() overfetching

### DIFF
--- a/src/Standard.php
+++ b/src/Standard.php
@@ -282,6 +282,7 @@ class Standard implements IteratorAggregate, Countable
     {
         while ($input->valid()) {
             yield iterator_to_array(self::take($input, $length), $preserve_keys);
+            $input->next();
         }
     }
 
@@ -752,12 +753,13 @@ class Standard implements IteratorAggregate, Countable
     {
         while ($input->valid()) {
             yield $input->key() => $input->current();
-            $input->next();
 
             // Stop once taken enough.
             if (0 === --$take) {
                 break;
             }
+
+            $input->next();
         }
     }
 
@@ -920,6 +922,9 @@ class Standard implements IteratorAggregate, Countable
             yield $output;
         }
 
+        // Fetch the next value
+        $input->next();
+
         // Return if there's nothing more to fetch
         if (!$input->valid()) {
             return;
@@ -955,6 +960,9 @@ class Standard implements IteratorAggregate, Countable
             yield $output;
             $sum += $weightFunc($output);
         }
+
+        // Fetch the next value
+        $input->next();
 
         // Return if there's nothing more to fetch
         if (!$input->valid()) {

--- a/tests/SliceTest.php
+++ b/tests/SliceTest.php
@@ -162,6 +162,20 @@ final class SliceTest extends TestCase
         );
     }
 
+    public function testTakeOnlyAsMuch(): void
+    {
+        $values = fromArray([1, 2, 3, 4])
+            ->stream()
+            ->cast(function ($value) {
+                $this->assertLessThan(3, $value);
+                return $value;
+            })
+            ->slice(0, 2)
+            ->toAssoc();
+
+        $this->assertSame([1, 2], $values);
+    }
+
     public function testSliceNil(): void
     {
         $pipeline = new Standard();


### PR DESCRIPTION
It will pull one more value from the iterator even if you ask for N.