### PR TITLE
Implement toList(), deprecate toArray()

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ All entry points always return an instance of the pipeline.
 | `each()`     | Eagerly iterates over the sequence. | `foreach`, `array_walk` |
 | `stream()` | Ensures subsequent operations use lazy, non-array paths | |
 | `runningCount()` | Counts seen values using a reference argument. | |
-| `toArray()` | Returns an array with all values. Eagerly executed. | `dict`, `ToDictionary` |
-| `toAssoc()` | Returns an array with all values and keys. Eagerly executed. |  |
+| `toList()` | Returns an array with all values. Eagerly executed. |  |
+| `toAssoc()` | Returns an array with all values and keys. Eagerly executed. | `dict`, `ToDictionary` |
 | `runningVariance()` | Computes online statistics: sample mean, sample variance, standard deviation. | [Welford's method](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm) |
 | `finalVariance()` | Computes final statistics for the sequence. |   |
 | `__construct()` | Can be provided with an optional initial iterator. Used in the `take()` function from above.  |     |
@@ -195,13 +195,13 @@ In general, Pipeline instances are mutable, meaning every Pipeline-returning met
 	/* ['foo' => 'baz'] */
     ```
   
-  Safer would be to use provided `toArray()` method. It will return all values regardless of keys used, making sure to discard all keys in the process.
+  Safer would be to use provided `toList()` method. It will return all values regardless of keys used, making sure to discard all keys in the process.
   
     ```php
-    var_dump($pipeline->toArray());
+    var_dump($pipeline->toList());
     /* ['bar', 'baz'] */
     ```
-  This method also takes an optional argument to keep the keys.
+  If necessary to preserve the keys, there's a sister method `toAssoc()`.
 
 - The resulting pipeline is an iterator and should be assumed not rewindable, just like generators it uses.
 
@@ -275,7 +275,7 @@ Flatten inputs:
 $pipeline->map(function () {
     yield [1];
     yield [2, 3];
-})->unpack()->toArray();
+})->unpack()->toList();
 // [1, 2, 3]
 ```
 
@@ -376,7 +376,7 @@ $total = $pipeline->reduce(function ($curry, $item) {
 
 The pipeline has a default callback that sums all values.
 
-## `$pipeline->toArray()`
+## `$pipeline->toList()`
 
 Returns an array with all values from a pipeline. All array keys are ignored to make sure every single value is returned.
 
@@ -393,7 +393,7 @@ $pipeline->map(function ($i) {
     yield $i + 2;
 });
 
-$result = $pipeline->toArray();
+$result = $pipeline->toList();
 // Since keys are ignored we get:
 // [2, 3, 3, 4]
 ```

--- a/example.php
+++ b/example.php
@@ -123,7 +123,7 @@ var_dump($result);
 //     int(62)
 // }
 
-// Now an example for toArray()
+// Now an example for toList()
 // Yields [0 => 1, 1 => 2]
 $pipeline = map(function () {
     yield 1;
@@ -139,7 +139,7 @@ $pipeline->map(function ($value) {
 // remove first and last elements
 $pipeline->slice(1, -1);
 
-$arrayResult = $pipeline->toArray();
+$arrayResult = $pipeline->toList();
 var_dump($arrayResult);
 // Since keys are discarded we get:
 // array(4) {

--- a/tests/ArraysTest.php
+++ b/tests/ArraysTest.php
@@ -52,7 +52,7 @@ final class ArraysTest extends TestCase
             return 42;
         });
 
-        $this->assertSame([42], $pipeline->toArray());
+        $this->assertSame([42], $pipeline->toList());
     }
 
     public function testArrayFilter(): void
@@ -62,7 +62,7 @@ final class ArraysTest extends TestCase
             return false;
         })->filter()->filter();
 
-        $this->assertSame([], $pipeline->toArray());
+        $this->assertSame([], $pipeline->toList());
     }
 
     public function testArrayReduce(): void
@@ -87,6 +87,6 @@ final class ArraysTest extends TestCase
             2 => 2,
         ]);
 
-        $this->assertSame([1, 2], $pipeline->toArray());
+        $this->assertSame([1, 2], $pipeline->toList());
     }
 }

--- a/tests/CastTest.php
+++ b/tests/CastTest.php
@@ -54,7 +54,7 @@ final class CastTest extends TestCase
 
     public function testCastNothing(): void
     {
-        $this->assertSame([1, 2, 3], take([1, 2, 3])->cast()->toArray());
+        $this->assertSame([1, 2, 3], take([1, 2, 3])->cast()->toList());
     }
 
     public function testCastIterator(): void
@@ -65,7 +65,7 @@ final class CastTest extends TestCase
             yield 3;
         })->cast(function (int $a) {
             return $a * 2;
-        })->toArray());
+        })->toList());
     }
 
     public function testCastSeedValue(): void
@@ -74,7 +74,7 @@ final class CastTest extends TestCase
 
         $this->assertSame([M_PI], $pipeline->cast(function () {
             return M_PI;
-        })->toArray());
+        })->toList());
     }
 
     public function testCastUnpack(): void
@@ -90,7 +90,7 @@ final class CastTest extends TestCase
             return $b - $a;
         });
 
-        $this->assertSame([0, 2, 6], $pipeline->toArray());
+        $this->assertSame([0, 2, 6], $pipeline->toList());
     }
 
     public function testCastPreservesKeys(): void
@@ -104,6 +104,6 @@ final class CastTest extends TestCase
             yield 'b' => 3;
         })->cast(function (int $a) {
             return $a * 2;
-        })->toArray(true));
+        })->toAssoc());
     }
 }

--- a/tests/ChunkTest.php
+++ b/tests/ChunkTest.php
@@ -94,6 +94,6 @@ final class ChunkTest extends TestCase
 
         $pipeline->chunk(100);
 
-        $this->assertSame([], $pipeline->toArray());
+        $this->assertSame([], $pipeline->toList());
     }
 }

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -84,7 +84,7 @@ final class DocumentationTest extends TestCase
 
     public function testProvideMethods(): void
     {
-        $methods = take(self::provideMethods())->toArray();
+        $methods = take(self::provideMethods())->toList();
 
         $this->assertGreaterThan(0, $methods, 'No public methods found.');
     }

--- a/tests/EachTest.php
+++ b/tests/EachTest.php
@@ -132,7 +132,7 @@ final class EachTest extends TestCase
         });
 
         $this->assertSame([1, 2], $this->output);
-        $this->assertSame([], $pipeline->toArray());
+        $this->assertSame([], $pipeline->toList());
     }
 
     public function testNoDiscard(): void
@@ -148,7 +148,7 @@ final class EachTest extends TestCase
         });
 
         $this->assertSame([1, 2, 3, 1, 2, 3], $this->output);
-        $this->assertSame([], $pipeline->toArray());
+        $this->assertSame([], $pipeline->toList());
     }
 
 }

--- a/tests/EagerWithArraysTest.php
+++ b/tests/EagerWithArraysTest.php
@@ -55,10 +55,10 @@ final class EagerWithArraysTest extends TestCase
 
         $this->assertSame([2 => 1, 2, 3], $reflectionProperty->getValue($pipeline));
 
-        $this->assertSame([1, 2, 3], $pipeline->toArray());
+        $this->assertSame([1, 2, 3], $pipeline->toList());
 
         // This does nothing more
-        $this->assertSame([1, 2, 3], $pipeline->filter()->toArray());
+        $this->assertSame([1, 2, 3], $pipeline->filter()->toList());
     }
 
     /**
@@ -90,10 +90,10 @@ final class EagerWithArraysTest extends TestCase
     {
         $this->assertSame([1, 1, 1, 1, 1], $pipeline->map(function ($value) {
             return 1;
-        })->toArray());
+        })->toList());
 
         // This should not be possible even with an array, as map() is always lazy
         $this->expectExceptionMessage('Cannot traverse an already closed generator');
-        $pipeline->toArray();
+        $pipeline->toList();
     }
 }

--- a/tests/EdgeCasesTest.php
+++ b/tests/EdgeCasesTest.php
@@ -64,7 +64,7 @@ final class EdgeCasesTest extends TestCase
 
         $pipeline->filter();
 
-        $this->assertCount(0, $pipeline->toArray());
+        $this->assertCount(0, $pipeline->toList());
     }
 
     /**
@@ -85,7 +85,7 @@ final class EdgeCasesTest extends TestCase
 
         $pipeline->filter('intval');
 
-        $this->assertCount(0, $pipeline->toArray());
+        $this->assertCount(0, $pipeline->toList());
     }
 
     public function testNonUniqueKeys(): void
@@ -107,7 +107,7 @@ final class EdgeCasesTest extends TestCase
         $this->assertSame([
             'bar',
             'baz',
-        ], $pipeline->toArray());
+        ], $pipeline->toList());
     }
 
     public function testMapUnprimed(): void
@@ -117,7 +117,7 @@ final class EdgeCasesTest extends TestCase
             return 1;
         });
 
-        $this->assertSame([1], $pipeline->toArray());
+        $this->assertSame([1], $pipeline->toList());
     }
 
     public function testFilterUnprimed(): void
@@ -125,7 +125,7 @@ final class EdgeCasesTest extends TestCase
         $pipeline = new Standard();
         $pipeline->filter()->unpack();
 
-        $this->assertSame([], $pipeline->toArray());
+        $this->assertSame([], $pipeline->toList());
     }
 
     public function testUnpackUnprimed(): void
@@ -135,7 +135,7 @@ final class EdgeCasesTest extends TestCase
             return 1;
         });
 
-        $this->assertSame([1], $pipeline->toArray());
+        $this->assertSame([1], $pipeline->toList());
     }
 
     public function testInitialInvokeReturnsScalar(): void
@@ -192,7 +192,7 @@ final class EdgeCasesTest extends TestCase
 
     public function testIteratorToArrayWithAllValues(): void
     {
-        $this->assertSame([2, 3, 3, 4], $this->pipelineWithNonUniqueKeys()->toArray());
+        $this->assertSame([2, 3, 3, 4], $this->pipelineWithNonUniqueKeys()->toList());
     }
 
     public function testInvokeMaps(): void

--- a/tests/ErrorsTest.php
+++ b/tests/ErrorsTest.php
@@ -78,6 +78,6 @@ final class ErrorsTest extends TestCase
         if (is_callable([$this, 'expectExceptionMessageMatches'])) {
             $this->expectExceptionMessageMatches('/must .* (iterable|Traversable)/');
         }
-        $pipeline->toArray();
+        $pipeline->toList();
     }
 }

--- a/tests/FlipTest.php
+++ b/tests/FlipTest.php
@@ -48,7 +48,7 @@ final class FlipTest extends TestCase
             yield 'b' => 2;
             yield 'c' => 2;
             yield 'd' => 3;
-        })->flip()->toArray();
+        })->flip()->toList();
 
         $this->assertSame(['a', 'b', 'c', 'd'], $keys);
     }
@@ -60,7 +60,7 @@ final class FlipTest extends TestCase
             yield 'b' => 2;
             yield 'c' => 2;
             yield 'd' => 3;
-        })->flip()->toArray(true);
+        })->flip()->toAssoc();
 
         $this->assertSame([1 => 'a', 'c', 'd'], $keys);
     }
@@ -141,11 +141,11 @@ final class FlipTest extends TestCase
      */
     public function testFlip(array $expected, iterable $input): void
     {
-        $this->assertSame($expected, take($input)->flip()->toArray(true));
+        $this->assertSame($expected, take($input)->flip()->toAssoc());
     }
 
     public function testNonPrimedFlip(): void
     {
-        $this->assertSame([], (new Standard())->flip()->toArray());
+        $this->assertSame([], (new Standard())->flip()->toList());
     }
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -81,7 +81,7 @@ final class FunctionsTest extends TestCase
      */
     public function testTakeArray(): void
     {
-        $this->assertSame([1, 2, 3, 4, 5], take([1, 2, 3, 4, 5])->toArray());
+        $this->assertSame([1, 2, 3, 4, 5], take([1, 2, 3, 4, 5])->toList());
     }
 
     /**
@@ -89,9 +89,9 @@ final class FunctionsTest extends TestCase
      */
     public function testTakeMany(): void
     {
-        $this->assertSame([1, 2, 3, 4, 5], take([1, 2], [3, 4], [5])->toArray());
+        $this->assertSame([1, 2, 3, 4, 5], take([1, 2], [3, 4], [5])->toList());
 
-        $this->assertSame([1, 2, 3, 4, 5], take(take([1, 2]), take([3, 4]), fromValues(5))->toArray());
+        $this->assertSame([1, 2, 3, 4, 5], take(take([1, 2]), take([3, 4]), fromValues(5))->toList());
     }
 
     /**
@@ -99,8 +99,8 @@ final class FunctionsTest extends TestCase
      */
     public function testFromValues(): void
     {
-        $this->assertSame([1, 2, 3, 4, 5], fromValues(1, 2, 3, 4, 5)->toArray());
-        $this->assertSame([1, 2, 3], fromValues(...[1, 2, 3])->toArray());
+        $this->assertSame([1, 2, 3, 4, 5], fromValues(1, 2, 3, 4, 5)->toList());
+        $this->assertSame([1, 2, 3], fromValues(...[1, 2, 3])->toList());
     }
 
     /**
@@ -110,7 +110,7 @@ final class FunctionsTest extends TestCase
     {
         $pipeline = fromArray(range(0, 100));
         $this->assertInstanceOf(Standard::class, $pipeline);
-        $this->assertSame(range(0, 100), $pipeline->toArray());
+        $this->assertSame(range(0, 100), $pipeline->toList());
     }
 
     /**
@@ -119,13 +119,13 @@ final class FunctionsTest extends TestCase
     public function testZip(): void
     {
         $pipeline = zip([1, 2], [3, 4]);
-        $this->assertSame([[1, 3], [2, 4]], $pipeline->toArray());
+        $this->assertSame([[1, 3], [2, 4]], $pipeline->toList());
 
         $array = [[1, 2, 3], [4, 5, 6], [7, 8, 9]];
 
         $pipeline = zip(...$array);
         $this->assertInstanceOf(Standard::class, $pipeline);
 
-        $this->assertSame(array_map(null, ...$array), $pipeline->toArray());
+        $this->assertSame(array_map(null, ...$array), $pipeline->toList());
     }
 }

--- a/tests/Helper/RunningVarianceTest.php
+++ b/tests/Helper/RunningVarianceTest.php
@@ -241,7 +241,7 @@ final class RunningVarianceTest extends TestCase
     public function testNumericStability(int $count, float $mean, float $sigma): void
     {
         $numbers = take(self::getRandomNumbers($mean, $sigma))
-            ->slice(0, $count)->toArray();
+            ->slice(0, $count)->toList();
 
         $benchmark = self::standard_deviation($numbers);
 
@@ -273,7 +273,7 @@ final class RunningVarianceTest extends TestCase
     {
         $numbers = take(self::getRandomNumbers($mean, $sigma))
             ->slice(0, $count)
-            ->toArray();
+            ->toList();
 
         try {
             $this->assertEqualsWithDelta($sigma, self::standard_deviation(

--- a/tests/IterableTest.php
+++ b/tests/IterableTest.php
@@ -35,7 +35,7 @@ final class IterableTest extends TestCase
     public function testArrayToArray(): void
     {
         $pipeline = new Standard([1, 2, 3]);
-        $this->assertSame([1, 2, 3], $pipeline->toArray());
+        $this->assertSame([1, 2, 3], $pipeline->toList());
     }
 
     public function testArrayToIterator(): void
@@ -53,13 +53,13 @@ final class IterableTest extends TestCase
             yield $value;
         })->filter()->unpack();
 
-        $this->assertSame([], $pipeline->toArray());
+        $this->assertSame([], $pipeline->toList());
     }
 
     public function testArrayFilter(): void
     {
         $pipeline = new Standard([0, 1, 2, 3, 0]);
-        $this->assertSame([1, 2, 3], $pipeline->filter()->toArray());
+        $this->assertSame([1, 2, 3], $pipeline->filter()->toList());
     }
 
     public function testArrayMap(): void
@@ -67,7 +67,7 @@ final class IterableTest extends TestCase
         $pipeline = new Standard([1 => 0, 1, 2, 3]);
         $this->assertSame([0 => 0, 1, 2, 3], $pipeline->map(function ($value) {
             return $value;
-        })->toArray());
+        })->toList());
     }
 
     public function testArrayMapFilter(): void
@@ -75,6 +75,6 @@ final class IterableTest extends TestCase
         $pipeline = new Standard([1 => 0, 1, 2, 3]);
         $this->assertSame([0 => 1, 2, 3], $pipeline->map(function ($value) {
             return $value;
-        })->filter()->toArray());
+        })->filter()->toList());
     }
 }

--- a/tests/KeysTest.php
+++ b/tests/KeysTest.php
@@ -57,7 +57,7 @@ final class KeysTest extends TestCase
             yield 6 => 'b';
             yield 5 => 'c';
             yield 6 => 'a';
-        })->keys()->toArray();
+        })->keys()->toList();
 
         $this->assertSame([5, 6, 5, 6], $keys);
     }
@@ -77,6 +77,6 @@ final class KeysTest extends TestCase
 
     public function testNonPrimed(): void
     {
-        $this->assertSame([], (new Standard())->keys()->toArray());
+        $this->assertSame([], (new Standard())->keys()->toList());
     }
 }

--- a/tests/MapTest.php
+++ b/tests/MapTest.php
@@ -42,6 +42,6 @@ final class MapTest extends TestCase
             yield 'b' => 3;
         })->map(function (int $a) {
             return $a * 2;
-        })->toArray(true));
+        })->toAssoc());
     }
 }

--- a/tests/ReservoirTest.php
+++ b/tests/ReservoirTest.php
@@ -52,7 +52,7 @@ final class ReservoirTest extends TestCase
             [20, 17, 11, 13, 18, 13],
             take(range(0, 5))->map(function () {
                 return mt_rand(10, 20);
-            })->toArray()
+            })->toList()
         );
     }
 
@@ -167,7 +167,7 @@ final class ReservoirTest extends TestCase
         $this->assertSame($expected, $pipeline->reservoir($size, $weightFn));
 
         if ($size <= 0) {
-            $this->assertSame([], $pipeline->toArray());
+            $this->assertSame([], $pipeline->toList());
         }
     }
 

--- a/tests/SkipWhileTest.php
+++ b/tests/SkipWhileTest.php
@@ -39,7 +39,7 @@ final class SkipWhileTest extends TestCase
 
         $result = $pipeline
             ->skipWhile(fn($number) => 1 === $number)
-            ->toArray();
+            ->toList();
 
         $this->assertSame([], $result);
     }
@@ -48,7 +48,7 @@ final class SkipWhileTest extends TestCase
     {
         $result = take([2])
             ->skipWhile(fn($number) => 1 === $number)
-            ->toArray();
+            ->toList();
 
         $this->assertSame([2], $result);
     }
@@ -57,7 +57,7 @@ final class SkipWhileTest extends TestCase
     {
         $result = take([1, 1, 1, 2, 3, 4, 1, 2, 3])
             ->skipWhile(fn($number) => 1 === $number)
-            ->toArray();
+            ->toList();
 
         $this->assertSame([2, 3, 4, 1, 2, 3], $result);
     }
@@ -68,7 +68,7 @@ final class SkipWhileTest extends TestCase
             ->skipWhile(fn($number) => 1 === $number)
             ->skipWhile(fn($number) => 2 === $number)
             ->filter(fn($number) => 1 === $number % 2)
-            ->toArray();
+            ->toList();
 
         $this->assertSame([3, 5, 1], $result);
     }

--- a/tests/SliceTest.php
+++ b/tests/SliceTest.php
@@ -79,42 +79,42 @@ final class SliceTest extends TestCase
     {
         $this->assertSame(
             [3, 4, 5],
-            $example()->slice(2, 3)->toArray()
+            $example()->slice(2, 3)->toList()
         );
 
         $this->assertSame(
             [6],
-            $example()->slice(5, 200)->toArray()
+            $example()->slice(5, 200)->toList()
         );
 
         $this->assertSame(
             [],
-            $example()->slice(15, 200)->toArray()
+            $example()->slice(15, 200)->toList()
         );
 
         $this->assertSame(
             [5, 6],
-            $example()->slice(-2)->toArray()
+            $example()->slice(-2)->toList()
         );
 
         $this->assertSame(
             [2, 3, 4],
-            $example()->slice(-5, -2)->toArray()
+            $example()->slice(-5, -2)->toList()
         );
 
         $this->assertSame(
             [1, 2, 3],
-            $example()->slice(0, -3)->toArray()
+            $example()->slice(0, -3)->toList()
         );
 
         $this->assertSame(
             [1, 2, 3],
-            $example()->slice(0, 3)->toArray()
+            $example()->slice(0, 3)->toList()
         );
 
         $this->assertSame(
             [2, 3, 4, 5],
-            $example()->slice(1, -1)->toArray()
+            $example()->slice(1, -1)->toList()
         );
     }
 
@@ -128,37 +128,37 @@ final class SliceTest extends TestCase
 
         $this->assertSame(
             ['c' => 3, 'd' => 4, 'e' => 5],
-            $example()->slice(2, 3)->toArray(true)
+            $example()->slice(2, 3)->toAssoc()
         );
 
         $this->assertSame(
             ['f' => 6],
-            $example()->slice(5, 200)->toArray(true)
+            $example()->slice(5, 200)->toAssoc()
         );
 
         $this->assertSame(
             [],
-            $example()->slice(15, 200)->toArray(true)
+            $example()->slice(15, 200)->toAssoc()
         );
 
         $this->assertSame(
             ['e' => 5, 'f' => 6],
-            $example()->slice(-2)->toArray(true)
+            $example()->slice(-2)->toAssoc()
         );
 
         $this->assertSame(
             ['b' => 2, 'c' => 3, 'd' => 4],
-            $example()->slice(-5, -2)->toArray(true)
+            $example()->slice(-5, -2)->toAssoc()
         );
 
         $this->assertSame(
             ['a' => 1, 'b' => 2, 'c' => 3],
-            $example()->slice(0, -3)->toArray(true)
+            $example()->slice(0, -3)->toAssoc()
         );
 
         $this->assertSame(
             ['b' => 2, 'c' => 3, 'd' => 4, 'e' => 5],
-            $example()->slice(1, -1)->toArray(true)
+            $example()->slice(1, -1)->toAssoc()
         );
     }
 
@@ -180,7 +180,7 @@ final class SliceTest extends TestCase
     {
         $pipeline = new Standard();
 
-        $this->assertSame([], $pipeline->slice(0)->toArray());
+        $this->assertSame([], $pipeline->slice(0)->toList());
     }
 
     public static function specimens(): iterable
@@ -329,7 +329,7 @@ final class SliceTest extends TestCase
         });
 
         try {
-            $pipeline->slice(0)->toArray();
+            $pipeline->slice(0)->toList();
         } catch (RuntimeException $e) {
             // We must not have any static methods called.
             $this->assertStringNotContainsString('Standard::', (string) $e);
@@ -358,6 +358,6 @@ final class SliceTest extends TestCase
 
         $this->assertSame([
             0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584, 4181,
-        ], $fibonacci->slice(0, 20)->toArray());
+        ], $fibonacci->slice(0, 20)->toList());
     }
 }

--- a/tests/StandardTest.php
+++ b/tests/StandardTest.php
@@ -46,7 +46,7 @@ final class StandardTest extends TestCase
         $this->assertSame([], iterator_to_array(new Standard()));
 
         $pipeline = new Standard();
-        $this->assertSame([], $pipeline->toArray());
+        $this->assertSame([], $pipeline->toList());
 
         $this->assertSame(0, iterator_count(new Standard()));
     }
@@ -89,7 +89,7 @@ final class StandardTest extends TestCase
             yield $i * 1000;
         });
 
-        $this->assertSame([10, 100, 1000, 20, 200, 2000, 30, 300, 3000], $pipeline->toArray());
+        $this->assertSame([10, 100, 1000, 20, 200, 2000, 30, 300, 3000], $pipeline->toList());
     }
 
     public function testTriple(): void
@@ -116,7 +116,7 @@ final class StandardTest extends TestCase
             }
         });
 
-        $this->assertSame([52, 104], $pipeline->toArray());
+        $this->assertSame([52, 104], $pipeline->toList());
     }
 
     public function testFilter(): void
@@ -139,7 +139,7 @@ final class StandardTest extends TestCase
 
         $pipeline->filter();
 
-        $this->assertSame([6, 13, 20, 27, 34, 41, 48], $pipeline->toArray());
+        $this->assertSame([6, 13, 20, 27, 34, 41, 48], $pipeline->toList());
     }
 
     public function testReduce(): void
@@ -306,7 +306,7 @@ final class StandardTest extends TestCase
         $pipeline->map($this->double);
         $pipeline->map($this->plusone);
 
-        $this->assertSame([4, 5, 8, 9, 12, 13, 16, 17, 20, 21], $pipeline->toArray());
+        $this->assertSame([4, 5, 8, 9, 12, 13, 16, 17, 20, 21], $pipeline->toList());
     }
 
     public function testMethodChaining(): void
@@ -363,12 +363,12 @@ final class StandardTest extends TestCase
         $this->assertSame([
             1,
             2,
-        ], $pipeline->toArray());
+        ], $pipeline->toList());
 
         $this->assertSame([
             'a' => 1,
             'b' => 2,
-        ], $pipeline->toArray(true));
+        ], $pipeline->toAssoc());
     }
 
     public function testToArrayWithArrayPreservingKeys(): void
@@ -382,6 +382,32 @@ final class StandardTest extends TestCase
             'a' => 1,
             'b' => 2,
         ], $pipeline->toArrayPreservingKeys());
+    }
+
+    public function testToArrayDefault(): void
+    {
+        $pipeline = fromArray([
+            'a' => 1,
+            'b' => 2,
+        ]);
+
+        $this->assertSame([
+            1,
+            2,
+        ], $pipeline->toList());
+    }
+
+    public function testToArrayWithKeys(): void
+    {
+        $pipeline = fromArray([
+            'a' => 1,
+            'b' => 2,
+        ]);
+
+        $this->assertSame([
+            'a' => 1,
+            'b' => 2,
+        ], $pipeline->toArray(preserve_keys: true));
     }
 
     public function testToAssoc(): void
@@ -407,7 +433,7 @@ final class StandardTest extends TestCase
         $this->assertSame([
             1,
             2,
-        ], $pipeline->toArray());
+        ], $pipeline->toList());
 
         $pipeline = map(function () {
             yield 'a' => 1;
@@ -417,7 +443,7 @@ final class StandardTest extends TestCase
         $this->assertSame([
             'a' => 1,
             'b' => 2,
-        ], $pipeline->toArray(true));
+        ], $pipeline->toAssoc());
     }
 
     public function testToAssocWithIterator(): void

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -84,6 +84,6 @@ final class StreamTest extends TestCase
 
     public function testNonPrimed(): void
     {
-        $this->assertSame([], (new Standard())->stream()->toArray());
+        $this->assertSame([], (new Standard())->stream()->toList());
     }
 }

--- a/tests/TuplesTest.php
+++ b/tests/TuplesTest.php
@@ -102,7 +102,7 @@ final class TuplesTest extends TestCase
     {
         $pipeline = new Standard();
 
-        $actual = $pipeline->tuples()->toArray();
+        $actual = $pipeline->tuples()->toList();
 
         $this->assertSame(
             [],

--- a/tests/UnpackTest.php
+++ b/tests/UnpackTest.php
@@ -81,7 +81,7 @@ final class UnpackTest extends TestCase
             new ArrayIterator([1]),
             fromArray([2]),
             [3],
-        ])->unpack()->toArray());
+        ])->unpack()->toList());
     }
 
     /**
@@ -93,6 +93,6 @@ final class UnpackTest extends TestCase
             new ArrayIterator([1]),
             fromArray([2]),
             [3],
-        ])->flatten()->toArray());
+        ])->flatten()->toList());
     }
 }

--- a/tests/ValuesTest.php
+++ b/tests/ValuesTest.php
@@ -57,7 +57,7 @@ final class ValuesTest extends TestCase
             yield 6 => 'b';
             yield 5 => 'c';
             yield 6 => 'd';
-        })->values()->toArray();
+        })->values()->toList();
 
         $this->assertSame(['a', 'b', 'c', 'd'], $values);
     }
@@ -77,6 +77,6 @@ final class ValuesTest extends TestCase
 
     public function testNonPrimedFlip(): void
     {
-        $this->assertSame([], (new Standard())->values()->toArray());
+        $this->assertSame([], (new Standard())->values()->toList());
     }
 }

--- a/tests/ZipTest.php
+++ b/tests/ZipTest.php
@@ -47,7 +47,7 @@ final class ZipTest extends TestCase
         $pipeline = new Standard();
 
         $pipeline->zip([1, 2], [3, 4]);
-        $this->assertSame([[1, 3], [2, 4]], $pipeline->toArray());
+        $this->assertSame([[1, 3], [2, 4]], $pipeline->toList());
 
         $array = [[1, 2, 3], [4, 5, 6], [7, 8, 9]];
 
@@ -55,7 +55,7 @@ final class ZipTest extends TestCase
 
         $pipeline->zip(...$array);
 
-        $this->assertSame(array_map(null, ...$array), $pipeline->toArray());
+        $this->assertSame(array_map(null, ...$array), $pipeline->toList());
     }
 
     /**
@@ -67,7 +67,7 @@ final class ZipTest extends TestCase
 
         $pipeline->zip(fromArray([3, 4]));
 
-        $this->assertSame([[1, 3], [2, 4]], $pipeline->toArray());
+        $this->assertSame([[1, 3], [2, 4]], $pipeline->toList());
     }
 
     /**
@@ -85,7 +85,7 @@ final class ZipTest extends TestCase
             yield 4;
         }));
 
-        $this->assertSame([[1, 3], [2, 4]], $pipeline->toArray());
+        $this->assertSame([[1, 3], [2, 4]], $pipeline->toList());
     }
 
     /**
@@ -96,19 +96,19 @@ final class ZipTest extends TestCase
         $pipeline = new Standard();
         $pipeline->zip([3, 4]);
 
-        $this->assertSame([3, 4], $pipeline->toArray());
+        $this->assertSame([3, 4], $pipeline->toList());
     }
 
     public function testZipEmpty(): void
     {
-        $this->assertSame([], take([])->zip([1, 2, 3])->toArray());
+        $this->assertSame([], take([])->zip([1, 2, 3])->toList());
     }
 
     public function testZipUnequalLengths(): void
     {
         $actual = take(['a', 'b', 'c'])
             ->zip([1, 2], [3])
-            ->toArray();
+            ->toList();
 
         $this->assertSame([
             ['a', 1, 3],
@@ -121,7 +121,7 @@ final class ZipTest extends TestCase
     {
         $actual = take(['a', 'b', 'c'])
             ->zip([1], [2, 3])
-            ->toArray();
+            ->toList();
 
         $this->assertSame([
             ['a', 1, 2],
@@ -134,7 +134,7 @@ final class ZipTest extends TestCase
     {
         $actual = take(['a', 'b', 'c'])
             ->zip(range(1, 10), range(10, 100, 10))
-            ->toArray();
+            ->toList();
 
         $this->assertSame([
             ['a', 1, 10],
@@ -147,14 +147,14 @@ final class ZipTest extends TestCase
     {
         $pipeline = new Standard();
 
-        $this->assertSame([], $pipeline->zip([])->toArray());
+        $this->assertSame([], $pipeline->zip([])->toList());
     }
 
     public function testZipNothingNothing(): void
     {
         $pipeline = new Standard();
 
-        $this->assertSame([], $pipeline->zip()->toArray());
+        $this->assertSame([], $pipeline->zip()->toList());
     }
 
     public function testExample(): void


### PR DESCRIPTION
Fix #177

Let's add a pair of non-confusing methods.