### PR TITLE
Add strict mode to filter() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,12 +352,8 @@ $pipeline->filter(function ($item) {
 
 The pipeline has a default callback with the same effect as in `array_filter`: it'll remove all falsy values.
 
-With the optional `strict` parameter:
+With the optional `strict` parameter, it only removes strictly `null` or `false`:
 ```php
-// Default behavior - removes all falsy values (false, 0, '', '0', [], null)
-$pipeline->filter();
-
-// Strict mode - only removes null and false
 $pipeline->filter(strict: true);
 ```
 

--- a/README.md
+++ b/README.md
@@ -352,6 +352,15 @@ $pipeline->filter(function ($item) {
 
 The pipeline has a default callback with the same effect as in `array_filter`: it'll remove all falsy values.
 
+With the optional `strict` parameter:
+```php
+// Default behavior - removes all falsy values (false, 0, '', '0', [], null)
+$pipeline->filter();
+
+// Strict mode - only removes null and false
+$pipeline->filter(strict: true);
+```
+
 ## `$pipeline->slice()`
 
 Takes offset and length arguments, functioning in a very similar fashion to how `array_slice` does with `$preserve_keys` set to true.

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -30,6 +30,7 @@
         <MissingClosureParamType errorLevel="suppress" />
         <MissingClosureReturnType errorLevel="suppress" />
         <ClassMustBeFinal errorLevel="suppress" />
+        <PrivateFinalMethod errorLevel="suppress" />
 
         <RedundantPropertyInitializationCheck errorLevel="suppress" />
         <PropertyNotSetInConstructor errorLevel="suppress" />

--- a/src/Standard.php
+++ b/src/Standard.php
@@ -402,7 +402,7 @@ class Standard implements IteratorAggregate, Countable
      * With no callback drops all null and false values (not unlike array_filter does by default).
      *
      * @param ?callable $func
-     * @param bool      $strict When true with no callback, only null and false are filtered out
+     * @param bool      $strict When true, only `null` and `false` are filtered out
      *
      * @return $this
      */
@@ -441,6 +441,14 @@ class Standard implements IteratorAggregate, Countable
 
         if (null === $func) {
             return self::nonStrictPredicate(...);
+        }
+
+        // Handle strict mode for user provided predicates.
+        if ($strict) {
+            return static function ($value) use ($func) {
+                $value = $func($value);
+                return self::strictPredicate($value);
+            };
         }
 
         // Strings usually are internal functions, which typically require exactly one parameter.

--- a/src/Standard.php
+++ b/src/Standard.php
@@ -476,7 +476,6 @@ class Standard implements IteratorAggregate, Countable
         return static fn($value) => $func($value);
     }
 
-
     /**
      * Skips elements while the predicate returns true, and keeps everything after the predicate return false just once.
      *

--- a/src/Standard.php
+++ b/src/Standard.php
@@ -435,16 +435,12 @@ class Standard implements IteratorAggregate, Countable
      */
     private static function resolvePredicate(?callable $func, bool $strict = false): callable
     {
-        if (null === $func) {
-            if (!$strict) {
-                // Cast is unnecessary for non-strict filtering
-                return static function ($value) {
-                    return $value;
-                };
-            }
+        if (null === $func && $strict) {
+            return self::strictPredicate(...);
+        }
 
-            // Strict mode: only filter out null and false
-            return static fn($value) => null !== $value && false !== $value;
+        if (null === $func) {
+            return self::nonStrictPredicate(...);
         }
 
         // Strings usually are internal functions, which typically require exactly one parameter.
@@ -453,6 +449,16 @@ class Standard implements IteratorAggregate, Countable
         }
 
         return $func;
+    }
+
+    private static function strictPredicate($value): bool
+    {
+        return null !== $value && false !== $value;
+    }
+
+    private static function nonStrictPredicate($value): bool
+    {
+        return (bool) $value;
     }
 
     /**

--- a/src/Standard.php
+++ b/src/Standard.php
@@ -450,15 +450,16 @@ class Standard implements IteratorAggregate, Countable
             };
         }
 
+        /** @phan-suppress-next-line PhanTypeMismatchArgumentNullable */
         return self::resolveStringPredicate($func);
     }
 
-    private static function strictPredicate($value): bool
+    private static function strictPredicate(mixed $value): bool
     {
         return null !== $value && false !== $value;
     }
 
-    private static function nonStrictPredicate($value): bool
+    private static function nonStrictPredicate(mixed $value): bool
     {
         return (bool) $value;
     }

--- a/tests/EdgeCasesTest.php
+++ b/tests/EdgeCasesTest.php
@@ -51,8 +51,7 @@ final class EdgeCasesTest extends TestCase
      */
     public function testFilterAnyFalseValueDefaultCallback(): void
     {
-        $pipeline = new Standard();
-        $pipeline->map(function () {
+        $pipeline = map(function () {
             yield false;
             yield 0;
             yield 0.0;
@@ -72,29 +71,7 @@ final class EdgeCasesTest extends TestCase
      */
     public function testFilterAnyFalseValueCustomCallback(): void
     {
-        $pipeline = new Standard();
-        $pipeline->map(function () {
-            yield false;
-            yield 0;
-            yield 0.0;
-            yield '';
-            yield '0';
-            yield [];
-            yield null;
-        });
-
-        $pipeline->filter('intval');
-
-        $this->assertCount(0, $pipeline->toList());
-    }
-
-    /**
-     * @covers \Pipeline\Standard::filter()
-     */
-    public function testFilterStrictMode(): void
-    {
-        $pipeline = new Standard();
-        $pipeline->map(function () {
+        $pipeline = map(function () {
             yield false;
             yield 0;
             yield 0.0;
@@ -103,30 +80,36 @@ final class EdgeCasesTest extends TestCase
             yield [];
             yield null;
             yield 1;
-            yield 'hello';
         });
 
-        $pipeline->filter(strict: true);
+        $pipeline->filter('intval');
 
-        $result = $pipeline->toList();
-
-        // In strict mode, only null and false are filtered out
-        $this->assertCount(7, $result);
-        $this->assertSame([0, 0.0, '', '0', [], 1, 'hello'], $result);
+        $this->assertSame([1], $pipeline->toList());
     }
 
     /**
      * @covers \Pipeline\Standard::filter()
      */
-    public function testFilterStrictModeWithArrays(): void
+    public function testFilterStrictMode(): void
     {
-        $pipeline = \Pipeline\fromArray([false, 0, 0.0, '', '0', [], null, 1, 'hello']);
+        $nonStrictFalsyValues = [
+            0,
+            0.0,
+            '',
+            '0',
+            [],
+        ];
 
-        $result = $pipeline->filter(strict: true)->toList();
+        $pipeline = map(function () use ($nonStrictFalsyValues) {
+            yield false;
+            yield null;
 
-        // In strict mode, only null and false are filtered out
-        $this->assertCount(7, $result);
-        $this->assertSame([0, 0.0, '', '0', [], 1, 'hello'], $result);
+            yield from $nonStrictFalsyValues;
+        });
+
+        $pipeline->filter(strict: true);
+
+        $this->assertSame($nonStrictFalsyValues, $pipeline->toList());
     }
 
     public function testNonUniqueKeys(): void

--- a/tests/EdgeCasesTest.php
+++ b/tests/EdgeCasesTest.php
@@ -88,6 +88,47 @@ final class EdgeCasesTest extends TestCase
         $this->assertCount(0, $pipeline->toList());
     }
 
+    /**
+     * @covers \Pipeline\Standard::filter()
+     */
+    public function testFilterStrictMode(): void
+    {
+        $pipeline = new Standard();
+        $pipeline->map(function () {
+            yield false;
+            yield 0;
+            yield 0.0;
+            yield '';
+            yield '0';
+            yield [];
+            yield null;
+            yield 1;
+            yield 'hello';
+        });
+
+        $pipeline->filter(strict: true);
+
+        $result = $pipeline->toList();
+
+        // In strict mode, only null and false are filtered out
+        $this->assertCount(7, $result);
+        $this->assertSame([0, 0.0, '', '0', [], 1, 'hello'], $result);
+    }
+
+    /**
+     * @covers \Pipeline\Standard::filter()
+     */
+    public function testFilterStrictModeWithArrays(): void
+    {
+        $pipeline = \Pipeline\fromArray([false, 0, 0.0, '', '0', [], null, 1, 'hello']);
+
+        $result = $pipeline->filter(strict: true)->toList();
+
+        // In strict mode, only null and false are filtered out
+        $this->assertCount(7, $result);
+        $this->assertSame([0, 0.0, '', '0', [], 1, 'hello'], $result);
+    }
+
     public function testNonUniqueKeys(): void
     {
         $pipeline = \Pipeline\map(function () {

--- a/tests/EdgeCasesTest.php
+++ b/tests/EdgeCasesTest.php
@@ -40,92 +40,6 @@ use function range;
  */
 final class EdgeCasesTest extends TestCase
 {
-    public function testStandardStringFunctions(): void
-    {
-        $pipeline = new Standard(new ArrayIterator([1, 2, 'foo', 'bar']));
-        $pipeline->filter('is_int');
-
-        $this->assertSame([1, 2], iterator_to_array($pipeline));
-    }
-
-    /**
-     * @covers \Pipeline\Standard::filter()
-     */
-    public function testFilterAnyFalseValueDefaultCallback(): void
-    {
-        $pipeline = map(function () {
-            yield false;
-            yield 0;
-            yield 0.0;
-            yield '';
-            yield '0';
-            yield [];
-            yield null;
-        });
-
-        $pipeline->filter();
-
-        $this->assertCount(0, $pipeline->toList());
-    }
-
-    /**
-     * @covers \Pipeline\Standard::filter()
-     */
-    public function testFilterAnyFalseValueCustomCallback(): void
-    {
-        $pipeline = map(function () {
-            yield false;
-            yield 0;
-            yield 0.0;
-            yield '';
-            yield '0';
-            yield [];
-            yield null;
-            yield 1;
-        });
-
-        $pipeline->filter('intval');
-
-        $this->assertSame([1], $pipeline->toList());
-    }
-
-    /**
-     * @covers \Pipeline\Standard::filter()
-     * @covers \Pipeline\Standard::resolvePredicate()
-     */
-    public function testFilterStrictMode(): void
-    {
-        $nonStrictFalsyValues = [
-            0,
-            0.0,
-            '',
-            '0',
-            [],
-        ];
-
-        $pipeline = map(function () use ($nonStrictFalsyValues) {
-            yield false;
-            yield null;
-
-            yield from $nonStrictFalsyValues;
-        });
-
-        $pipeline->filter(strict: true);
-
-        $this->assertSame($nonStrictFalsyValues, $pipeline->toList());
-    }
-
-    /**
-     * @covers \Pipeline\Standard::filter()
-     * @covers \Pipeline\Standard::resolvePredicate()
-     */
-    public function testFilterNonStrictMode(): void
-    {
-        $pipeline = fromValues(false, null, '');
-        $pipeline->filter(strict: false);
-        $this->assertCount(0, $pipeline);
-    }
-
     public function testNonUniqueKeys(): void
     {
         $pipeline = \Pipeline\map(function () {
@@ -158,23 +72,6 @@ final class EdgeCasesTest extends TestCase
         $this->assertSame([1], $pipeline->toList());
     }
 
-    public function testFilterUnprimed(): void
-    {
-        $pipeline = new Standard();
-        $pipeline->filter()->unpack();
-
-        $this->assertSame([], $pipeline->toList());
-    }
-
-    public function testUnpackUnprimed(): void
-    {
-        $pipeline = new Standard();
-        $pipeline->unpack(function () {
-            return 1;
-        });
-
-        $this->assertSame([1], $pipeline->toList());
-    }
 
     public function testInitialInvokeReturnsScalar(): void
     {

--- a/tests/EdgeCasesTest.php
+++ b/tests/EdgeCasesTest.php
@@ -28,6 +28,8 @@ use PHPUnit\Framework\TestCase;
 use Pipeline\Standard;
 
 use function iterator_to_array;
+use function Pipeline\fromArray;
+use function Pipeline\fromValues;
 use function Pipeline\map;
 use function range;
 
@@ -89,6 +91,7 @@ final class EdgeCasesTest extends TestCase
 
     /**
      * @covers \Pipeline\Standard::filter()
+     * @covers \Pipeline\Standard::resolvePredicate()
      */
     public function testFilterStrictMode(): void
     {
@@ -110,6 +113,17 @@ final class EdgeCasesTest extends TestCase
         $pipeline->filter(strict: true);
 
         $this->assertSame($nonStrictFalsyValues, $pipeline->toList());
+    }
+
+    /**
+     * @covers \Pipeline\Standard::filter()
+     * @covers \Pipeline\Standard::resolvePredicate()
+     */
+    public function testFilterNonStrictMode(): void
+    {
+        $pipeline = fromValues(false, null, '');
+        $pipeline->filter(strict: false);
+        $this->assertCount(0, $pipeline);
     }
 
     public function testNonUniqueKeys(): void

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * Copyright 2017, 2018 Alexey Kopytko <alexey@kopytko.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Pipeline;
+
+use ArrayIterator;
+use Iterator;
+use IteratorIterator;
+use NoRewindIterator;
+use PHPUnit\Framework\TestCase;
+use Pipeline\Standard;
+
+use function iterator_to_array;
+use function Pipeline\fromArray;
+use function Pipeline\fromValues;
+use function Pipeline\map;
+use function range;
+
+/**
+ * @covers \Pipeline\Standard
+ *
+ * @internal
+ */
+final class FilterTest extends TestCase
+{
+    private const NON_STRICT_FALSE_VALUES = [
+        0,
+        0.0,
+        '',
+        '0',
+        [],
+    ];
+
+    public function testStandardStringFunctions(): void
+    {
+        $pipeline = new Standard(new ArrayIterator([1, 2, 'foo', 'bar']));
+        $pipeline->filter('is_int');
+
+        $this->assertSame([1, 2], iterator_to_array($pipeline));
+    }
+
+    public function testFilterAnyFalseValueDefaultCallback(): void
+    {
+        $pipeline = map(function () {
+            yield false;
+            yield 0;
+            yield 0.0;
+            yield '';
+            yield '0';
+            yield [];
+            yield null;
+        });
+
+        $pipeline->filter();
+
+        $this->assertCount(0, $pipeline->toList());
+    }
+
+    public function testFilterAnyFalseValueCustomCallback(): void
+    {
+        $pipeline = map(function () {
+            yield false;
+            yield 0;
+            yield 0.0;
+            yield '';
+            yield '0';
+            yield [];
+            yield null;
+            yield 1;
+        });
+
+        $pipeline->filter('intval');
+
+        $this->assertSame([1], $pipeline->toList());
+    }
+
+    public function testFilterStrictMode(): void
+    {
+        $pipeline = map(function () {
+            yield false;
+            yield null;
+
+            yield from self::NON_STRICT_FALSE_VALUES;
+        });
+
+        $pipeline->filter(strict: true);
+
+        $this->assertSame(self::NON_STRICT_FALSE_VALUES, $pipeline->toList());
+    }
+
+    public function testFilterStrictModeWithPredicate(): void
+    {
+        $pipeline = map(function () {
+            yield false;
+            yield null;
+
+            yield from self::NON_STRICT_FALSE_VALUES;
+        });
+
+        $pipeline->filter(fn($value) => $value, strict: true);
+
+        $this->assertSame(self::NON_STRICT_FALSE_VALUES, $pipeline->toList());
+    }
+
+    public function testFilterNonStrictMode(): void
+    {
+        $pipeline = fromValues(false, null, '');
+        $pipeline->filter(strict: false);
+        $this->assertCount(0, $pipeline);
+    }
+
+    public function testFilterUnprimed(): void
+    {
+        $pipeline = new Standard();
+        $pipeline->filter()->unpack();
+
+        $this->assertSame([], $pipeline->toList());
+    }
+}

--- a/tests/SkipWhileTest.php
+++ b/tests/SkipWhileTest.php
@@ -23,6 +23,7 @@ namespace Tests\Pipeline;
 use PHPUnit\Framework\TestCase;
 use Pipeline\Standard;
 
+use function Pipeline\fromValues;
 use function Pipeline\map;
 use function Pipeline\take;
 
@@ -71,5 +72,14 @@ final class SkipWhileTest extends TestCase
             ->toList();
 
         $this->assertSame([3, 5, 1], $result);
+    }
+
+    public function testDefaultCallback(): void
+    {
+        $result = fromValues(1, '0', null, false)
+            ->skipWhile(fn($number) => $number)
+            ->toList();
+
+        $this->assertSame(['0', null, false], $result);
     }
 }

--- a/tests/StaticAnalysisTest.php
+++ b/tests/StaticAnalysisTest.php
@@ -125,7 +125,7 @@ final class StaticAnalysisTest extends TestCase
                 return $this;
             }
 
-            public function filter(?callable $func = null): self
+            public function filter(?callable $func = null, bool $strict = false): self
             {
                 return $this;
             }

--- a/tests/UnpackTest.php
+++ b/tests/UnpackTest.php
@@ -22,6 +22,7 @@ namespace Tests\Pipeline;
 
 use ArrayIterator;
 use PHPUnit\Framework\TestCase;
+use Pipeline\Standard;
 
 use function Pipeline\fromArray;
 use function round;
@@ -94,5 +95,15 @@ final class UnpackTest extends TestCase
             fromArray([2]),
             [3],
         ])->flatten()->toList());
+    }
+
+    public function testUnpackUnprimed(): void
+    {
+        $pipeline = new Standard();
+        $pipeline->unpack(function () {
+            return 1;
+        });
+
+        $this->assertSame([1], $pipeline->toList());
     }
 }


### PR DESCRIPTION
## Summary
- Adds an optional `$strict` parameter to the `filter()` method
- When strict mode is enabled with no callback, only `null` and `false` values are filtered out
- Other falsy values like `0`, `''`, `'0'`, and `[]` are preserved in strict mode

## Motivation
This provides a middle ground between filtering all falsy values (default behavior) and keeping everything. It's particularly useful when working with:
- Numeric data where `0` and `0.0` are valid values
- Form inputs where empty strings are distinct from missing values
- String representations of numbers where `'0'` is valid data

## Changes
- Modified `filter()` method to accept optional `bool $strict = false` parameter
- Updated `resolvePredicate()` to handle strict mode
- Added comprehensive tests in `EdgeCasesTest`
- Updated documentation in README.md
- Fixed compatibility in `StaticAnalysisTest`

## Test plan
- [x] Added new test cases for strict mode with generators
- [x] Added new test cases for strict mode with arrays
- [x] All existing tests pass
- [x] Static analysis passes

🤖 Generated with [Claude Code](https://claude.ai/code)