### PR TITLE
Fix the issue with first-class callables

### DIFF
--- a/src/Standard.php
+++ b/src/Standard.php
@@ -73,9 +73,11 @@ class Standard implements IteratorAggregate, Countable
      */
     public function __construct(?iterable $input = null)
     {
-        if (null !== $input) {
-            $this->replace($input);
+        if (null === $input) {
+            return;
         }
+
+        $this->replace($input);
     }
 
     private function replace(iterable $input): void
@@ -255,7 +257,7 @@ class Standard implements IteratorAggregate, Countable
      * @template TUnpackKey
      * @template TUnpack
      *
-     * @param null|callable(mixed...): (TUnpack|Generator<TUnpackKey, TUnpack, mixed, mixed>) $func A callback that accepts any number of arguments and returns a single value.
+     * @param null|callable(mixed...): (TUnpack|Generator<TUnpackKey, TUnpack>) $func A callback that accepts any number of arguments and returns a single value.
      *
      * @phpstan-self-out self<TUnpackKey, TUnpack>
      * @return Standard<TUnpackKey, TUnpack>
@@ -325,7 +327,7 @@ class Standard implements IteratorAggregate, Countable
      * @template TMapKey
      * @template TMapValue
      *
-     * @param null|(callable(): (TMapValue|Generator<TMapKey, TMapValue, mixed, mixed>))|(callable(TValue): (TMapValue|Generator<TMapKey, TMapValue, mixed, mixed>)) $func A callback must either return a value or yield values (return a generator).
+     * @param null|(callable(): (TMapValue|Generator<TMapKey, TMapValue>))|(callable(TValue): (TMapValue|Generator<TMapKey, TMapValue>)) $func A callback must either return a value or yield values (return a generator).
      *
      * @phpstan-self-out self<TMapKey, TMapValue>
      * @return Standard<TMapKey, TMapValue>
@@ -502,11 +504,7 @@ class Standard implements IteratorAggregate, Countable
      */
     private static function resolveStringPredicate(callable $func): callable
     {
-        if (!is_string($func)) {
-            return $func;
-        }
-
-        // Strings usually are internal functions, which typically require exactly one parameter.
+        // Make sure we pass only one argument the callback, as CallbackFilterIterator provides three
         return static fn($value) => $func($value);
     }
 

--- a/tests/AppendPrependTest.php
+++ b/tests/AppendPrependTest.php
@@ -27,9 +27,6 @@ use function count;
 use function is_numeric;
 use function key;
 use function Pipeline\take;
-use function reset;
-
-use const PHP_VERSION_ID;
 
 /**
  * @covers \Pipeline\Standard
@@ -80,8 +77,6 @@ final class AppendPrependTest extends TestCase
      */
     public function testPush(array $expected, ?array $initialValue, ...$iterables): void
     {
-        $this->skipOnPHP7($expected);
-
         $pipeline = take($initialValue);
 
         foreach ($iterables as $iterable) {
@@ -137,8 +132,6 @@ final class AppendPrependTest extends TestCase
      */
     public function testUnshift(array $expected, ?array $initialValue, ...$iterables): void
     {
-        $this->skipOnPHP7($expected);
-
         $pipeline = take($initialValue);
 
         foreach ($iterables as $iterable) {
@@ -168,12 +161,5 @@ final class AppendPrependTest extends TestCase
 
         $preserve_keys = !is_numeric(key($expected));
         $this->assertSame($expected, $pipeline->toArray($preserve_keys));
-    }
-
-    private function skipOnPHP7(array $expected): void
-    {
-        if (!is_numeric(reset($expected)) && PHP_VERSION_ID < 80000) {
-            $this->markTestSkipped('PHP 7 fails with an error: Cannot unpack array with string keys');
-        }
     }
 }

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -56,6 +56,14 @@ final class FilterTest extends TestCase
         $this->assertSame([1, 2], iterator_to_array($pipeline));
     }
 
+    public function testStandardFunctions(): void
+    {
+        $pipeline = new Standard(new ArrayIterator([1, 2, 'foo', 'bar']));
+        $pipeline->filter(is_int(...));
+
+        $this->assertSame([1, 2], iterator_to_array($pipeline));
+    }
+
     public function testFilterAnyFalseValueDefaultCallback(): void
     {
         $pipeline = map(function () {

--- a/tests/ReservoirTest.php
+++ b/tests/ReservoirTest.php
@@ -166,9 +166,11 @@ final class ReservoirTest extends TestCase
 
         $this->assertSame($expected, $pipeline->reservoir($size, $weightFn));
 
-        if ($size <= 0) {
-            $this->assertSame([], $pipeline->toList());
+        if ($size > 0) {
+            return;
         }
+
+        $this->assertSame([], $pipeline->toList());
     }
 
     /**


### PR DESCRIPTION
  This PR addresses a runtime issue where PHP's `CallbackFilterIterator` passes 3 arguments to callbacks, which was incompatible with first-class callable syntax. The class was updated to wrap callbacks to ensure they only receive one argument (before it was done only for string arguments).